### PR TITLE
Add pip dependency caching to CI workflow

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          apt-get update
-          apt-get install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
             git \
             build-essential \
             libgl1-mesa-dev \


### PR DESCRIPTION
This PR updates "CI Workflow" to use `actions/setup-python` instead of a containerized Python environment.

This change improves workflow efficiency by enabling pip dependency caching, reducing install times on subsequent runs.