### PR TITLE
Remove redundant `mypy` arguments from CI workflow

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -54,14 +54,7 @@ jobs:
         run: ruff check --output-format=github --line-length 79
 
       - name: Run mypy
-        run: |
-          mypy \
-          --ignore-missing-imports \
-          --disallow-untyped-defs \
-          --strict-optional \
-          --warn-unused-ignores \
-          --disable-error-code type-arg \
-          .
+        run: mypy .
 
       - name: YAML Lint
         run: yamllint --strict .


### PR DESCRIPTION
This PR removes redundant `mypy` arguments from "CI Workflow" as they are already defined in `pyproject.toml`.