### PR TITLE
Wrap env steps with `torch.no_grad()`

### DIFF
--- a/examples/drone_ctbr_controller_example.py
+++ b/examples/drone_ctbr_controller_example.py
@@ -135,30 +135,32 @@ def main() -> None:
 
     # Simulate drone environment
     steps_per_command = num_steps // len(ctbr_env_action_list)
-    for step in range(num_steps):
-        # Calculate action idx for ctbr action selection
-        action_idx = step // steps_per_command
-        # Avoid out-of-bounds error
-        action_idx = min(action_idx, len(ctbr_env_action_list) - 1)
+    with torch.no_grad():
+        for step in range(num_steps):
+            # Calculate action idx for ctbr action selection
+            action_idx = step // steps_per_command
+            # Avoid out-of-bounds error
+            action_idx = min(action_idx, len(ctbr_env_action_list) - 1)
 
-        ctbr_env_action = ctbr_env_action_list[action_idx]
+            ctbr_env_action = ctbr_env_action_list[action_idx]
 
-        # Step simulation
-        env.step(ctbr_env_action)
+            # Step simulation
+            env.step(ctbr_env_action)
 
-        # Print control error for the env of idx 0 if verbose output is enabled
-        if verbose:
-            ctbr_measurement = torch.hstack(
-                [ctbr_env_action[0, 0], env.base_ang_vel[0, :]]
-            )
-            # Note: The total thrust is directly applied in the drone env,
-            # so we assume it immediately matches its setpoint
+            # Print control error for the env of idx 0
+            # if verbose output is enabled
+            if verbose:
+                ctbr_measurement = torch.hstack(
+                    [ctbr_env_action[0, 0], env.base_ang_vel[0, :]]
+                )
+                # Note: The total thrust is directly applied in the drone env,
+                # so we assume it immediately matches its setpoint
 
-            print_formatted_control_data(
-                setpoint=ctbr_env_action[0, :],
-                measurement=ctbr_measurement,
-                label="CTBR Controller",
-            )
+                print_formatted_control_data(
+                    setpoint=ctbr_env_action[0, :],
+                    measurement=ctbr_measurement,
+                    label="CTBR Controller",
+                )
 
 
 def print_formatted_control_data(

--- a/tests/controller_tests/drone_ctbr_controller_test.py
+++ b/tests/controller_tests/drone_ctbr_controller_test.py
@@ -57,8 +57,9 @@ def run_hover_test(env: HoverEnv, tol: float = 0.1, steps: int = 10) -> None:
     )
 
     # Step environment
-    for _ in range(steps):
-        env.step(env_action)
+    with torch.no_grad():
+        for _ in range(steps):
+            env.step(env_action)
 
     # Check that the drone is hovering statically
     assert torch.all(torch.abs(env.base_ang_vel) < tol), "Hover control fails"
@@ -85,8 +86,9 @@ def run_body_rate_test(
     )
 
     # Step environment
-    for _ in range(steps):
-        env.step(env_action)
+    with torch.no_grad():
+        for _ in range(steps):
+            env.step(env_action)
 
     # Check that the drone angular velocity error is small
     assert torch.allclose(env.base_ang_vel, test_setpoint[:, 1:], atol=tol), (

--- a/tests/env_tests/test_hover_env.py
+++ b/tests/env_tests/test_hover_env.py
@@ -33,21 +33,22 @@ def test_hover_env_loop(
 
     # Step environment
     num_steps = 5
-    for _ in range(num_steps):
-        dummy_actions = torch.zeros(
-            (num_envs, env.num_actions),
-            dtype=torch.float,
-            device=env.device,
-        )
-        obs, _, reward, done, info = env.step(dummy_actions)
+    with torch.no_grad():
+        for _ in range(num_steps):
+            dummy_actions = torch.zeros(
+                (num_envs, env.num_actions),
+                dtype=torch.float,
+                device=env.device,
+            )
+            obs, _, reward, done, info = env.step(dummy_actions)
 
-        assert obs.shape == (num_envs, env.num_obs)
-        assert reward.shape == (num_envs,)
-        assert done.shape == (num_envs,)
-        assert isinstance(info, dict)
+            assert obs.shape == (num_envs, env.num_obs)
+            assert reward.shape == (num_envs,)
+            assert done.shape == (num_envs,)
+            assert isinstance(info, dict)
 
-        # Check that rewards do not contain NaNs
-        assert not torch.isnan(reward).any(), "Reward contains NaNs"
+            # Check that rewards do not contain NaNs
+            assert not torch.isnan(reward).any(), "Reward contains NaNs"
 
     # Sanity check reward keys
     for k in dummy_reward_cfg["reward_scales"].keys():

--- a/tests/utility_tests/test_drone_utilities.py
+++ b/tests/utility_tests/test_drone_utilities.py
@@ -66,9 +66,10 @@ def test_hover_env_utilities(
     U = np.zeros((num_steps, m))
     Y = np.zeros((num_steps, p))
     W = system_model.eps_max * np.random.uniform(-1.0, 1.0, (num_steps, p))
-    for k in range(num_steps):
-        # Simulate drone
-        Y[k, :] = system_model.simulate_step(u=U[k, :], w=W[k, :])
+    with torch.no_grad():
+        for k in range(num_steps):
+            # Simulate drone
+            Y[k, :] = system_model.simulate_step(u=U[k, :], w=W[k, :])
 
     # Restore env state
     restore_env_from_state(


### PR DESCRIPTION
This PR disables gradient calculation in control loops by wrapping environment simulation steps with `torch.no_grad()`.
This is standard practice for PyTorch model evaluations that do not require backpropagation, and it helps reduce memory usage and improve performance.