### PR TITLE
Disable Codecov PR comments due to lack of useful info

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,6 +11,4 @@ coverage:
         target: auto
         informational: true
 
-comment:
-  layout: "reach, diff, files"
-  behavior: default
+comment: false


### PR DESCRIPTION
This PR disables Codecov PR comments, since it only provided generic information with the previous comment configuration when there were no patch errors. The message it displayed was:
`All modified and coverable lines are covered by tests`.

Despite testing different configurations, we were not able to configure Codecov to produce more useful comments.

Until further notice, Codecov will only be used as a reference and is disabled from commenting on PRs.

### Key changes:
- Set `comment: false` in `.codecov.yml` to disable Codecov PR comments.
