### PR TITLE
Fix calculation of at-target indices in drone environment

### DIFF
--- a/src/data_driven_quad_control/envs/hover_env.py
+++ b/src/data_driven_quad_control/envs/hover_env.py
@@ -347,20 +347,26 @@ class HoverEnv:
             torch.norm(self.rel_pos, dim=1) < self.at_target_threshold
         )
 
-        # Increment counters of drones that are at target
-        self.hover_counter[at_target_mask] += 1
-        # Reset counters for drones that moved away from the target
-        self.hover_counter[~at_target_mask] = 0
+        if self.min_hover_steps > 0:
+            # Increment counters of drones that are at target
+            self.hover_counter[at_target_mask] += 1
+            # Reset counters for drones that moved away from the target
+            self.hover_counter[~at_target_mask] = 0
 
-        # Get indices of drones stabilized at target
-        # (hovered at target for at least `min_hover_steps` steps)
-        stabilized_at_target = (
-            (self.hover_counter >= self.min_hover_steps)
-            .nonzero(as_tuple=False)
-            .flatten()
-        )
+            # Get indices of drones stabilized at target
+            # (hovered at target for at least `min_hover_steps` steps)
+            stabilized_at_target = (
+                (self.hover_counter >= self.min_hover_steps)
+                .nonzero(as_tuple=False)
+                .flatten()
+            )
 
-        return stabilized_at_target
+            return stabilized_at_target
+        else:
+            # Get indices of drones that reached the target
+            at_target = at_target_mask.nonzero(as_tuple=False).flatten()
+
+            return at_target
 
     def reset(self) -> tuple[torch.Tensor, None]:
         self.reset_buf[:] = True


### PR DESCRIPTION
This PR fixes the calculation of the indices of drones that are at target in `HoverEnv`. Specifically, for the case when the number of minimum steps at target (`min_hover_steps`) is zero.

Previously, all targets were updated instantly without checking if drones had actually reached them. This occurred because the condition required drones to hover for at least 0 steps, which was always true.

Now, only the indices of drones that are actually at target are returned.

### Key changes:
- Refactor `_hovering_at_target` in `HoverEnv` to return indices of drones that reach the target when `min_hover_steps <= 0` instead of returning every index.
- Add unit tests for `_hovering_at_target` in `test_hover_env.py`.
